### PR TITLE
Remove BOM workaround

### DIFF
--- a/src/functionalTest/groovy/com/devsoap/vaadinflow/FunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/devsoap/vaadinflow/FunctionalTest.groovy
@@ -36,7 +36,7 @@ class FunctionalTest extends Specification {
 
     static final String PLUGIN_ID = 'com.devsoap.vaadin-flow'
 
-    static final String TEST_VAADIN_VERSION = '10.0.3'
+    static final String TEST_VAADIN_VERSION = '10.0.4'
 
     @Rule
     protected TemporaryFolder testProjectDir

--- a/src/main/groovy/com/devsoap/vaadinflow/VaadinFlowPlugin.groovy
+++ b/src/main/groovy/com/devsoap/vaadinflow/VaadinFlowPlugin.groovy
@@ -103,46 +103,8 @@ class VaadinFlowPlugin implements Plugin<Project> {
                 create(ConvertGroovyTemplatesToHTML.NAME, ConvertGroovyTemplatesToHTML)
             }
 
-            workaroundInvalidBomVersionRanges(it)
-
             afterEvaluate {
                 disableStatistics(project)
-            }
-
-        }
-    }
-
-    /**
-     * Looks like vaadins BOM is using invalid version ranges which do not account for alpha/beta releases.
-     * Workaround it here by using the '+' notation.
-     *
-     * FIXME This is a ugly hack that should be removed once Vaadin gets its BOMs fixed.
-     *
-     * @param project
-     *      the project
-     */
-    private static void workaroundInvalidBomVersionRanges(Project project) {
-        project.configurations.all {
-            it.resolutionStrategy.eachDependency { dep ->
-                String group = dep.requested.group
-                String name = dep.requested.name
-                String version = dep.requested.version
-                if (group == 'org.webjars.bowergithub.vaadin') {
-                    if (name != 'vaadin-usage-statistics' && version.startsWith('[')) {
-                        dep.because('Dependency is using a unsupported range')
-                        dep.useVersion('latest.release')
-                    }
-                    if (name == 'vaadin-lumo-styles') {
-                        // Do not pull in lumo-styles Polymer 3 alpha/beta components
-                        dep.because('Latest lumo does not support bower')
-                        dep.useVersion('1.0.0')
-                    }
-                }
-                if (group == 'org.webjars.bowergithub.webcomponents' && name == 'shadycss') {
-                    // Lock shadycss (used by lumo-styles) as 1.3.x does no longer support bower
-                    dep.because('Latest shadycss does not support bower')
-                    dep.useVersion('1.2.1')
-                }
             }
         }
     }


### PR DESCRIPTION
The BOM workaround should no longer be needed after Vaadin fixed their
BOMS. This will require users to upgrade their Vaadin versions to latest
bugfix releases.

Fingers crossed the POM dependencies are fixed.