### PR TITLE
Fix issue with private field visibility (#140)

### DIFF
--- a/src/functionalTest/groovy/com/devsoap/vaadinflow/VaadinFlowPluginTest.groovy
+++ b/src/functionalTest/groovy/com/devsoap/vaadinflow/VaadinFlowPluginTest.groovy
@@ -236,4 +236,16 @@ class VaadinFlowPluginTest extends FunctionalTest {
         then:
             result.output.contains('Forcing a Vaadin version while also using the BOM is not recommended')
     }
+
+    void 'version check test'() {
+        setup:
+            buildFile << '''
+                vaadin.autoconfigure()
+            '''.stripIndent()
+        when:
+            BuildResult result = run('vaadinPluginVersionCheck')
+        then:
+            result.task(':vaadinPluginVersionCheck').outcome == SUCCESS
+            result.output.contains('You are using the latest plugin. Excellent!')
+    }
 }

--- a/src/main/groovy/com/devsoap/vaadinflow/tasks/VersionCheckTask.groovy
+++ b/src/main/groovy/com/devsoap/vaadinflow/tasks/VersionCheckTask.groovy
@@ -18,6 +18,7 @@ package com.devsoap.vaadinflow.tasks
 import com.devsoap.vaadinflow.VaadinFlowPlugin
 import com.devsoap.vaadinflow.util.Versions
 import groovy.transform.Memoized
+import groovy.transform.PackageScope
 import groovy.util.logging.Log
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.InputFile
@@ -43,7 +44,8 @@ class VersionCheckTask extends DefaultTask {
 
     @InputFile
     @OutputFile
-    private final File versionCacheFile = new File(project.buildDir, '.vaadin-gradle-flow-version.check')
+    @PackageScope
+    final File versionCacheFile = new File(project.buildDir, '.vaadin-gradle-flow-version.check')
 
     VersionCheckTask() {
         description = 'Checks if there is a newer version of the plugin available'


### PR DESCRIPTION
Since the versionCacheFile field is accessed from a closure it cannot
be private due to Groovy pecularities.