### PR TITLE
Add base theme property to resolve theme (#178)

### DIFF
--- a/src/functionalTest/groovy/com/devsoap/vaadinflow/ClientDependenciesTest.groovy
+++ b/src/functionalTest/groovy/com/devsoap/vaadinflow/ClientDependenciesTest.groovy
@@ -196,6 +196,7 @@ class ClientDependenciesTest extends FunctionalTest {
                 dependencies {
                   implementation vaadin.bom()
                   implementation vaadin.core()
+                  implementation vaadin.lumoTheme()
                   implementation vaadin.servletApi()
                 }
 

--- a/src/functionalTest/groovy/com/devsoap/vaadinflow/VaadinFlowPluginTest.groovy
+++ b/src/functionalTest/groovy/com/devsoap/vaadinflow/VaadinFlowPluginTest.groovy
@@ -64,7 +64,9 @@ class VaadinFlowPluginTest extends FunctionalTest {
                     vaadin.prereleases()
                 }
                 dependencies {
+                    implementation vaadin.bom()
                     implementation vaadin.core()
+                    implementation vaadin.lumoTheme()
                     compileOnly vaadin.servletApi()
                 }
             '''.stripIndent()
@@ -84,7 +86,7 @@ class VaadinFlowPluginTest extends FunctionalTest {
                     }
                     dependencies {
                         implementation vaadin.bom()
-                        implementation vaadin.dependency('lumo-theme', false)
+                        implementation vaadin.lumoTheme()
                         implementation vaadin.dependency('ordered-layout-flow', false)
                         implementation vaadin.dependency('button-flow', false)
                         implementation vaadin.dependency('core', false)

--- a/src/main/resources/vaadin-plugin.gdsl
+++ b/src/main/resources/vaadin-plugin.gdsl
@@ -40,12 +40,15 @@ contributor(vaadinCtx, {
         method name: 'slf4j', type: gradleDependencyType
         method name: 'disableStatistics', type: gradleDependencyType
         method name: 'groovy', type: gradleDependencyType
+        method name: 'lumoTheme', type: gradleDependencyType
+        method name: 'materialTheme', type: gradleDependencyType
 
     } else if(!enclosingMember()){
         method name: 'autoconfigure', type: Void.name, params: [:]
         property name: "version", type:  String.name
         property name: 'productionMode', type: Boolean.name
         property name: 'submitStatistics', type: Boolean.name
+        property name: 'baseTheme', type: String.name
     }
 })
 
@@ -57,6 +60,7 @@ contributor(closureCtx, {
         property name: "version", type: String.name
         property name: 'productionMode', type: Boolean.name
         property name: 'submitStatistics', type: Boolean.name
+        property name: 'baseTheme', type: String.name
     }
     if(enclosingCall('vaadinClientDependencies')) {
         property name: 'offlineCachePath', type: String.name


### PR DESCRIPTION
- Removes theme dependencies from vaadin.core() and vaadin.platform()
- Adds two new dependencies vaadin.lumoTheme() and
vaadin.materialTheme() to allow configuring which theme is used
- vaadin.autoconfigure() uses Lumo theme by default
- Adds property vaadin.baseTheme to manually configure theme setting