### PR TITLE
Close annotation scan result after use

### DIFF
--- a/src/main/groovy/com/devsoap/vaadinflow/tasks/TranspileDependenciesTask.groovy
+++ b/src/main/groovy/com/devsoap/vaadinflow/tasks/TranspileDependenciesTask.groovy
@@ -283,7 +283,9 @@ class TranspileDependenciesTask extends DefaultTask {
         }
     }
 
-    private void bundle(ScanResult scan) {
+    @Internal
+    @PackageScope
+    void bundle(ScanResult scan) {
 
         VaadinFlowPluginExtension vaadin = project.extensions.getByType(VaadinFlowPluginExtension)
 
@@ -379,7 +381,9 @@ class TranspileDependenciesTask extends DefaultTask {
         }
     }
 
-    private void checkIdUsage(ScanResult scan) {
+    @Internal
+    @PackageScope
+    void checkIdUsage(ScanResult scan) {
         if (!ignoreIdUsage) {
             List<String> ids = ClassIntrospectionUtils.findIdUsages(scan)
             if (!ids.isEmpty()) {
@@ -452,19 +456,21 @@ class TranspileDependenciesTask extends DefaultTask {
         }
 
         LOGGER.info('Performing annotation scan...')
-        ScanResult scan = LogUtils.measureTime('Scan completed') {
+        LogUtils.measureTime('Scan completed') {
             ClassIntrospectionUtils.getAnnotationScan(project)
-        }
-
-        if (vaadin.compatibilityMode) {
-            bundleInCompatibilityMode(scan)
-        } else {
-            checkIdUsage(scan)
-            bundle(scan)
+        }.withCloseable { ScanResult scan ->
+            if (vaadin.compatibilityMode) {
+                bundleInCompatibilityMode(scan)
+            } else {
+                checkIdUsage(scan)
+                bundle(scan)
+            }
         }
     }
 
-    private void bundleInCompatibilityMode(ScanResult scan) {
+    @Internal
+    @PackageScope
+    void bundleInCompatibilityMode(ScanResult scan) {
         LOGGER.info('Searching for HTML imports...')
         List<String> imports = initHTMLImportsFromComponents(scan)
 


### PR DESCRIPTION
According to https://github.com/classgraph/classgraph/wiki/API:-ScanResult the
scan result needs to be closed to free up memory. This is especially important
for when running the gradle build in deamon mode.