### PR TITLE
Add whitelist class scanning strategy (#309)

### DIFF
--- a/src/main/groovy/com/devsoap/vaadinflow/extensions/VaadinFlowPluginExtension.groovy
+++ b/src/main/groovy/com/devsoap/vaadinflow/extensions/VaadinFlowPluginExtension.groovy
@@ -58,6 +58,7 @@ class VaadinFlowPluginExtension {
     private static final String COMPATIBILITY_MODE_PROPERTY = 'vaadin.compatibilityMode'
     private static final String VAADIN_ROOT_PACKAGE = 'com.vaadin'
     private static final String GROOVY_STRING = 'groovy'
+    private static final String ROUTE = 'route'
 
     private final Property<String> version
     private final Property<Boolean> unsupportedVersion
@@ -65,6 +66,7 @@ class VaadinFlowPluginExtension {
     private final Property<Boolean> compatibilityMode
     private final Property<Boolean> submitStatistics
     private final ListProperty<String> whitelistedPackages
+    private final Property<String> scanStrategy
     private final Property<String> baseTheme
 
     private final DependencyHandler dependencyHandler
@@ -85,6 +87,7 @@ class VaadinFlowPluginExtension {
         compatibilityMode = project.objects.property(Boolean)
         submitStatistics = project.objects.property(Boolean)
         whitelistedPackages = project.objects.listProperty(String)
+        scanStrategy = project.objects.property(String)
         baseTheme = project.objects.property(String)
 
         project.afterEvaluate {
@@ -291,6 +294,36 @@ class VaadinFlowPluginExtension {
      */
     void setBaseTheme(String theme) {
         baseTheme.set(theme)
+    }
+
+    /**
+     * Get the strategy which the classpath scanner uses to resolve dependencies
+     *
+     * The strategy can be one of the following:
+     *   route - Uses @Route and scans all its referencing classes
+     *   whitelist - Finds all classes that matches the whitelistedPackages filter
+     *
+     * @return
+     *      the current strategy. By default 'route'
+     */
+    String getScanStrategy() {
+        scanStrategy.getOrElse(ROUTE)
+    }
+
+    /**
+     * Set the strategy which the classpath scanner uses to resolve dependencies
+     *
+     * The strategy can be one of the following:
+     *   route - Uses @Route and scans all its referencing classes
+     *   whitelist - Finds all classes that matches the whitelistedPackages filter
+     *
+     */
+    void setScanStrategy(String strategy) {
+        if (strategy in [ROUTE, 'whitelist']) {
+            scanStrategy.set(strategy)
+        } else {
+            throw new IllegalArgumentException("Scan strategy can either be 'route' or 'whitelist'.")
+        }
     }
 
     /**

--- a/src/main/groovy/com/devsoap/vaadinflow/util/ClassIntrospectionUtils.groovy
+++ b/src/main/groovy/com/devsoap/vaadinflow/util/ClassIntrospectionUtils.groovy
@@ -94,6 +94,15 @@ class ClassIntrospectionUtils {
         jsImports
     }
 
+    /**
+     * Get all Javascript imports by route
+     *
+     * @since 1.3
+     * @param scan
+     *       The classpath scan with the annotations
+     * @return
+     *        a list of Js imports
+     */
     static final Map<String, String> findJsImportsByRoute(ScanResult scan) {
         Map<String, String> modules = [:]
         List<String> processedClasses = []
@@ -102,6 +111,25 @@ class ClassIntrospectionUtils {
         }
         LOGGER.info("Scanned ${processedClasses.size()} classes.")
         modules
+    }
+
+    /**
+     * Get all Javascript imports by whitelist
+     *
+     * @since 1.3
+     * @param scan
+     *       The classpath scan with the annotations
+     * @return
+     *        a list of Js imports
+     */
+    static final Map<String, String> findJsImportsByWhitelist(ScanResult scan) {
+        Map<String, String> jsImports = [:]
+        scan.getClassesWithAnnotation(JS_IMPORT_FQN).each { clz ->
+            clz.getAnnotationInfoRepeatable(JS_IMPORT_FQN).each {
+                jsImports.put(it.parameterValues.value.value.toString(), clz.name)
+            }
+        }
+        jsImports
     }
 
     /**
@@ -143,14 +171,14 @@ class ClassIntrospectionUtils {
     }
 
     /**
-     * Find all JsModules in project
+     * Find all JsModules in project using route strategy
      *
      * @param scan
      *      the classpath scan with the annotations
      * @return
      *      the values of the js modules
      */
-    static final Map<String, String> findJsModules(ScanResult scan) {
+    static final Map<String, String> findJsModulesByRoute(ScanResult scan) {
         Map<String, String> modules = [:]
         List<String> processedClasses = []
         scan.getClassesWithAnnotation(ROUTE_FQN).each { ClassInfo ci ->
@@ -161,20 +189,61 @@ class ClassIntrospectionUtils {
     }
 
     /**
-     * Find all CSSImports in project
+     * Gets all JsModules from the whitelisted scan
+     *
+     * The whitelist is set in #VaadinFlowPluginExtension.whitelistedPackages and is performed
+     * when the scan is created.
+     *
+     * @param scan
+     *      the classpath scan with the annotations
+     * @return
+     *      the values of the js modules
+     */
+    static final Map<String,String> findJsModulesByWhitelist(ScanResult scan) {
+        Map<String, String> modules = [:]
+        scan.getClassesWithAnnotation(JS_MODULE_FQN).each { ClassInfo ci ->
+            ci.getAnnotationInfoRepeatable(JS_MODULE_FQN).each { AnnotationInfo a ->
+                modules[a.parameterValues.value.value.toString()] = ci.name
+            }
+        }
+        modules
+    }
+
+    /**
+     * Find all CSSImports in project using route strategy
+     *
      * @since 1.3
      * @param scan
-     *      the classpath scan with the annoations
+     *      the classpath scan with the annotations
      * @return
      *      the values of the css imports
      */
-    static final Map<String,String> findCssImports(ScanResult scan) {
+    static final Map<String,String> findCssImportsByRoute(ScanResult scan) {
         Map<String, String> imports = [:]
         List<String> processedClasses = []
         scan.getClassesWithAnnotation(ROUTE_FQN).each { ClassInfo ci ->
             findImportModulesByDependencies(ci, imports, CSS_IMPORT_FQN, processedClasses)
         }
         LOGGER.info("Scanned ${processedClasses.size()} classes.")
+        imports
+    }
+
+    /**
+     * Find all CSSImports in project using whitelist
+     *
+     * @since 1.3
+     * @param scan
+     *      the classpath scan with the annotations
+     * @return
+     *      the values of the css imports
+     */
+    static final Map<String,String> findCssImportsByWhitelist(ScanResult scan) {
+        Map<String, String> imports = [:]
+        scan.getClassesWithAnnotation(CSS_IMPORT_FQN).collect { ClassInfo ci ->
+            ci.getAnnotationInfoRepeatable(CSS_IMPORT_FQN).each { AnnotationInfo a ->
+                imports[a.parameterValues.value.value.toString()] = ci.name
+            }
+        }
         imports
     }
 

--- a/src/main/resources/vaadin-plugin.gdsl
+++ b/src/main/resources/vaadin-plugin.gdsl
@@ -56,6 +56,7 @@ contributor(vaadinCtx, {
         property name: 'submitStatistics', type: Boolean.name
         property name: 'baseTheme', type: String.name
         property name: 'whitelistedPackages', type: String[].name
+        property name: 'scanStrategy', type: String.name
     }
 })
 
@@ -71,6 +72,7 @@ contributor(closureCtx, {
         property name: 'submitStatistics', type: Boolean.name
         property name: 'baseTheme', type: String.name
         property name: 'whitelistedPackages', type: String[].name
+        property name: 'scanStrategy', type: String.name
     }
     if(enclosingCall(vaadinClientProperty)) {
         property name: 'offlineCachePath', type: String.name


### PR DESCRIPTION
Adds a new scanning strategy 'whitelist' which allows you to find all
instances of annotated classes in the classpath. This might be required
if the @Route classes does not directly reference components (for instance
in the case of IOC frameworks.

Since when using the 'whitelist' scanning strategy all components which
conforms to the whitelist will be included in the bundle it is recommended
to manually configure the `vaadin.whitelistedPackages` property so that it
only lists packages which has the wanted components in the bundle.

For example:

```gradle
vaadin.scanStrategy = 'whitelist'
vaadin.whitelistedPackages = [
        'com.vaadin.flow.component.orderedlayout',
        'my.project.root.package'
]
```
Would only include the ordered layouts as well as your project packages.